### PR TITLE
added missing fifth player to the scoreboard

### DIFF
--- a/public/game.html
+++ b/public/game.html
@@ -81,6 +81,12 @@
 	  <h1 class="offline">OFFLINE</h1>
 	  <h4 class="tzar grey">TZAR</h1>
 	  </li>
+	  <li id="p4">
+	  <h3 class="p4">Player 5</h3>
+	  <h2>0</h2>
+	  <h1 class="offline">OFFLINE</h1>
+	  <h4 class="tzar grey">TZAR</h1>
+	  </li>
 	  <li id="p5">
 	  <h3 class="p5">Player 6</h3>
 	  <h2>0</h2>


### PR DESCRIPTION
I was playing in a group of five people, but the fifth player never showed up on the scoreboard.  It turns out it was a simple mistake in omitting player 5 from the scoreboard list in `public/game.html`.  I've included the change here.
